### PR TITLE
BTFSBTT-201: TRON-US branch off from v0.1.0, with changes for BTFSBTT…

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2019 Protocol Labs
+Copyright (c) 2019 TRON-US
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/go.mod
+++ b/go.mod
@@ -12,3 +12,5 @@ require (
 	github.com/multiformats/go-multiaddr v0.0.4
 	github.com/multiformats/go-multihash v0.0.5
 )
+
+go 1.13

--- a/options/unixfs.go
+++ b/options/unixfs.go
@@ -33,6 +33,8 @@ type UnixfsAddSettings struct {
 	FsCache  bool
 	NoCopy   bool
 
+	TokenMetadata string
+
 	Events   chan<- interface{}
 	Silent   bool
 	Progress bool
@@ -62,6 +64,8 @@ func UnixfsAddOptions(opts ...UnixfsAddOption) (*UnixfsAddSettings, cid.Prefix, 
 		OnlyHash: false,
 		FsCache:  false,
 		NoCopy:   false,
+
+		TokenMetadata: "",
 
 		Events:   nil,
 		Silent:   false,
@@ -237,6 +241,14 @@ func (unixfsOpts) HashOnly(hashOnly bool) UnixfsAddOption {
 func (unixfsOpts) Events(sink chan<- interface{}) UnixfsAddOption {
 	return func(settings *UnixfsAddSettings) error {
 		settings.Events = sink
+		return nil
+	}
+}
+
+// TokenMetadata specifies settings for the token metadata to add.
+func (unixfsOpts) TokenMetadata(tokenMetadata string) UnixfsAddOption {
+	return func(settings *UnixfsAddSettings) error {
+		settings.TokenMetadata = tokenMetadata
 		return nil
 	}
 }


### PR DESCRIPTION
The changes in options/unixfs.go is to add metadata option related types for BTFSBTT 201. 